### PR TITLE
Add FFT-based convolution extractor

### DIFF
--- a/deeplearning/src/main/java/FFT.java
+++ b/deeplearning/src/main/java/FFT.java
@@ -1,0 +1,268 @@
+package main.java;
+
+public class FFT {
+	/**
+	 * A naïve recursive implementation of the Cooley-Tukey FFT algorithm.
+	 * http://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm
+	 * 
+	 * @param x The values to be FFT'd
+	 * @param N length of x
+	 * @param s kind of offset, should be 1 in the beginning
+	 * @param o offset, should be 0 in the beginning
+	 * @return A 2d double array with the resulting complex numbers
+	 */
+	private static double[][] fftCooleyTukeyRec(double[][] x, int N, int s, int o) {
+		double[][] res = new double[N][2];
+		if (N == 1) {
+			res[0] = x[o].clone();
+		} else {
+			double[][] a = fftCooleyTukeyRec(x, N/2, 2*s, o);
+			double[][] b = fftCooleyTukeyRec(x, N/2, 2*s, o+s);
+			for (int k = 0; k <= N/2 -1; ++k) {
+				double[] ta = a[k];
+				double[] tb = b[k];
+				double er = Math.cos(-2*Math.PI*k/N);
+				double ei = Math.sin(-2*Math.PI*k/N);
+				double r = er*tb[0] - ei*tb[1];
+				double i = er*tb[1] + ei*tb[0];
+				res[k][0] = ta[0] + r;
+				res[k][1] = ta[1] + i;
+				res[k+N/2][0] = ta[0] - r;
+				res[k+N/2][1] = ta[1] - i;
+			}
+		}
+		return res;
+	}
+	
+	/**
+	 * A proxy to call fftCooleyTukeyRec. Maybe extend to choose between different FFT-implementations?
+	 * 
+	 * @param x An array of (real,img)-pairs to be transformed 
+	 * @return A transformed array of (real,img)-pairs
+	 */
+	private static double[][] fft1D(double [][] x) {
+		return fftCooleyTukeyRec(x, x.length, 1, 0);
+	}
+	
+	
+	/**
+	 * 1D (rows==1) or 2D FastFourierTransform
+	 * 
+	 * @param x real matrix to be FFT'd
+	 * @return complex matrix
+	 */
+	public static double[][][] fftReal1Dor2D(double[][] x) {
+		int rows = x.length;
+		int cols = x[0].length;
+
+		double[][][] y = new double[rows][][];
+		
+		for(int j = 0; j < rows; ++j) {
+			y[j] = fftReal1D(x[j]); 
+		}
+		
+		if(rows == 1) { /* 1D */
+			return y;
+		}
+		
+		double[][][] yt = transpose(y);
+		double[][][] z = new double[cols][][];
+		
+		for(int i = 0; i < cols; ++i) {
+			z[i] = fft1D(yt[i]); 
+		}
+
+		return transpose(z);
+	}
+	
+	/**
+	 * A proxy to call fft with real vector
+	 * 
+	 * @param x real vector to be FFT'd 
+	 * @return complex vector
+	 */
+	static double[][] fftReal1D(double[] x) {
+		return fft1D(realToComplex(x));
+	}
+	
+	
+	/**
+	 * Add zero imaginary part to a real vector
+	 * @param x real vector
+	 * @return complex vector
+	 */
+	private static double[][] realToComplex(double[] x) {
+		double[][] y = new double[x.length][2];
+		for(int i = 0; i < x.length; ++i) {
+			y[i][0] = x[i];
+		}
+		return y;
+	}
+	
+	/**
+	 * Drop imaginary part of a complex vector
+	 * @param x complex vector
+	 * @return real vector
+	 */
+	private static double[] complexToReal(double[][] x) {
+		double[] y = new double[x.length];
+		for(int i = 0; i < x.length; ++i) {
+			y[i] = x[i][0];
+		}
+		return y;
+	}
+	
+	/**
+	 * Drop imaginary part of a complex matrix
+	 * @param x complex matrix
+	 * @return real matrix
+	 */
+	private static double[][] complexToReal(double[][][] x) {
+		int rows = x.length;
+		int cols = x[0].length;
+		double[][] y = new double[rows][cols];
+		for(int j = 0; j < rows; ++j) {
+			for(int i = 0; i < cols; ++i) {
+				y[j][i] = x[j][i][0];
+			}
+		}
+		return y;
+	}
+	
+	/**
+	 * Swap real and imaginary parts of a vector
+	 * @param x imaginary vector
+	 * @return imaginary vector with real and imaginary parts swapped
+	 */
+	private static double[][] swappedRealImg(double[][] x) {
+		double[][] y = new double[x.length][2];
+		for(int i = 0; i < x.length; ++i) {
+			y[i][1] = x[i][0];
+			y[i][0] = x[i][1];
+		}
+		return y;
+	}
+	
+	/**
+	 * Inverse FastFourierTransform, using the fft()-function.
+	 * 
+	 * @param x complex array to be inverse-FFT'd
+	 * @return transformed complex array
+	 */
+	private static double[][] ifft(double [][] x) {
+		double[][] y = fft1D(swappedRealImg(x));
+		for (int i = 0; i < y.length; ++i) {
+			y[i][0] /= y.length;
+			y[i][1] /= y.length;
+		}
+		return swappedRealImg(y);
+	}
+	
+	/**
+	 * Inverse 1D (rows==1) or 2D FastFourierTransform, using the fft()-function.
+	 * 
+	 * @param x complex matrix to be inverse-FFT'd
+	 * @return transformed complex matrix
+	 */
+	private static double[][][] ifft(double[][][] x) {
+		int rows = x.length;
+		int cols = x[0].length;
+
+		double[][][] y = new double[rows][][];
+		
+		for(int j = 0; j < rows; ++j) {
+			y[j] = ifft(x[j]); 
+		}
+		
+		if(rows == 1) { /* 1D */
+			return y;
+		}
+		
+		double[][][] yt = transpose(y);
+		double[][][] z = new double[cols][][];
+		
+		for(int i = 0; i < cols; ++i) {
+			z[i] = ifft(yt[i]); 
+		}
+
+		return transpose(z);
+	}
+	
+	/**
+	 * Transposes the given 2D complex matrix
+	 * @param x 2D complex matrix
+	 * @return 2D complex matrix (transposed)
+	 */
+	private static double[][][] transpose(double[][][] x) {
+		int rows = x.length;
+		int cols = x[0].length;
+		double[][][] y = new double[cols][rows][2];
+		for(int j = 0; j < rows; ++j) { // looping over X's rows
+			for(int i = 0; i < cols; ++i) { // looping over X's cols
+				y[i][j][0] = x[j][i][0];
+				y[i][j][1] = x[j][i][1];
+			}
+		}
+		return y;
+	}
+	
+	/**
+	 * 1D complex dot-product
+	 * @param x 1D complex x
+	 * @param y 1D complex y of same size as x
+	 * @return 1D complex result of same size as x
+	 */
+	private static double[][] dotprod(double[][] x, double[][] y) {
+		if(x.length != y.length) throw new RuntimeException("Input vectors have different lengths");
+		double[][] z = new double[x.length][2];
+		for(int i = 0; i < x.length; ++i) {
+			z[i][0] = x[i][0]*y[i][0] - x[i][1]*y[i][1];
+			z[i][1] = x[i][0]*y[i][1] + x[i][1]*y[i][0];
+		}
+		return z;
+	}
+	
+	/**
+	 * 2D complex dot-product
+	 * @param x 2D complex x
+	 * @param y 2D complex y of same size as x
+	 * @return 2D complex result of same size as x
+	 */
+	private static double[][][] dotprod(double[][][] x, double[][][] y) {
+		if(x.length != y.length) throw new RuntimeException("Input matrices have different number of rows");
+		if(x[0].length != y[0].length) throw new RuntimeException("Input matrices have different number of columns");
+		
+		int rows = x.length;
+		int cols = x[0].length;
+		double[][][] z = new double[rows][cols][2];
+		for(int j = 0; j < rows; ++j) {
+			for(int i = 0; i < cols; ++i) {
+				z[j][i][0] = x[j][i][0]*y[j][i][0] - x[j][i][1]*y[j][i][1];
+				z[j][i][1] = x[j][i][0]*y[j][i][1] + x[j][i][1]*y[j][i][0];
+			}
+		}
+		return z;
+	}
+	
+	/**
+	 * Convolution in 1D with pre-calculated FFT's. The FFT's must be of the same length, and the pre-FFT inputs must be real.
+	 * 
+	 * @param fftx 
+	 * @param ffty
+	 * @return real vector of the convolution result
+	 */
+	static double[] convolveWithPreFFT(double[][] fftx, double ffty[][]) {
+		return complexToReal(ifft(dotprod(fftx, ffty)));
+	}
+	
+	/**
+	 * Convolution in 1-2D with pre-calculated FFT's. The FFT's must be of the same length, and the pre-FFT inputs must be real.
+	 * 
+	 * @param fftx 
+	 * @param ffty
+	 * @return real matrix of the convolution result
+	 */
+	static double[][] convolveWithPreFFT(double[][][] fftx, double ffty[][][]) {
+		return complexToReal(ifft(dotprod(fftx, ffty)));
+	}
+}

--- a/deeplearning/src/main/java/FFTConvolutionExtractor.java
+++ b/deeplearning/src/main/java/FFTConvolutionExtractor.java
@@ -1,0 +1,218 @@
+/**
+ * 
+ */
+package main.java;
+
+import java.util.Arrays;
+
+import main.java.DeepModelSettings.ConfigBaseLayer;
+import main.java.DeepModelSettings.ConfigFeatureExtractor;
+
+import org.apache.spark.mllib.linalg.BLAS;
+import org.apache.spark.mllib.linalg.DenseMatrix;
+import org.apache.spark.mllib.linalg.DenseVector;
+import org.apache.spark.mllib.linalg.Vector;
+
+/**
+ * @author blizzara
+ *
+ */
+public class FFTConvolutionExtractor implements Extractor {
+
+	private static final long serialVersionUID = -6605790709668749617L;
+	private PreProcessZCA preProcess; 		// pre-processing information 
+	
+	double[][][][] featureFFTs = null; // 1. features 2. rows 3. cols 4. real/img
+	double[] featureAdds = null;
+	
+	private int inputRows;
+	private int inputCols;
+	private int featureRows;
+	private int featureCols;
+	private int validRows;
+	private int validCols;
+	
+	public FFTConvolutionExtractor(ConfigBaseLayer configLayer, PreProcessZCA preProcess) {
+		setConfigLayer(configLayer);
+		this.preProcess = preProcess;
+	}
+	
+	
+	/* (non-Javadoc)
+	 * @see main.java.Extractor#setFeatures(org.apache.spark.mllib.linalg.Vector[])
+	 */
+	@Override
+	public void setFeatures(Vector[] features) {
+		/**
+		 * Should pre-process features, flip 'em, pad them to match input data size and calculate their FFT's
+		 */
+		//this.features = features;
+		DenseMatrix zca = preProcess != null ? preProcess.getZCA() : null;
+		DenseVector mean = preProcess != null ? preProcess.getMean() : null;
+		featureFFTs = new double[features.length][][][];
+		
+		if(mean != null) {
+			BLAS.gemv(false, 1.0, zca, mean, 0.0, mean); // whiten mean vector
+			featureAdds = new double[features.length];
+		}
+		
+		for(int i = 0; i < features.length; ++i) {
+			DenseVector feature = (DenseVector)features[i];
+			if(zca != null) {
+				BLAS.gemv(true, 1.0, zca, feature, 0.0, feature); // "de-whiten" features, instead of whitening data
+				featureAdds[i] = BLAS.dot(mean,feature); // the effect of the mean vector - to be added to each cell
+			}
+			featureFFTs[i] = FFT(pad(inputRows, inputCols, flip(vectorToMatrix(featureRows, featureCols, feature.toArray()))));
+			//BLAS.gemm(false, false, 1.0, V, ZCA, 0.0, ZCA);
+		}
+	}
+	
+	@Override
+	public void setConfigLayer(ConfigBaseLayer configLayer) {
+		ConfigFeatureExtractor conf = configLayer.getConfigFeatureExtractor(); 
+		inputCols = conf.getInputDim1();
+		inputRows = conf.getInputDim2();
+		if(inputCols == 0 || (inputCols & (inputCols-1)) != 0) throw new RuntimeException("Configured input dimension 1 is 0 or not power-of-two");
+		if(inputCols == 0 || (inputRows & (inputRows-1)) != 0) throw new RuntimeException("Configured input dimension 2 is 0 or not power-of-two");
+		
+		featureCols = conf.getFeatureDim1();
+		featureRows = conf.getFeatureDim2();
+		if(featureCols == 0 || featureCols > inputCols) throw new RuntimeException("Configured feature dimension 1 is 0 or > input dimension 1");
+		if(featureRows == 0 || featureRows > inputRows) throw new RuntimeException("Configured feature dimension 2 is 0 or > input dimension 2");
+		
+		validRows = inputRows - featureRows + 1;
+		validCols = inputCols - featureCols + 1;
+	}
+
+	/* (non-Javadoc)
+	 * @see main.java.Extractor#call(org.apache.spark.mllib.linalg.Vector)
+	 */
+	@Override
+	public Vector call(Vector data) throws Exception {
+		if(data.size() != inputRows*inputCols) throw new RuntimeException("Vector length does not match config");
+		assert featureFFTs != null: "Features must be set before call()!";
+		
+		double[] result = new double[(validRows*validCols)*featureFFTs.length];
+		int resultPos = 0;
+		double[][][] dataFFT = FFT(vectorToMatrix(inputRows, inputCols, data.toArray()));
+		for(int i = 0; i < featureFFTs.length; ++i) {
+			double[][][] featureFFT = featureFFTs[i];
+			double add = featureAdds != null ? featureAdds[i] : 0.0;
+			double[] tmp = matrixToVector(ConvolveWithPreFFTandStrip(dataFFT, featureFFT), add);
+			System.arraycopy(tmp, 0, result, resultPos, tmp.length);
+			resultPos += tmp.length;
+		}
+		return new DenseVector(result);
+	}
+	
+	/**
+	 * Does FFT for a real vector whose dimension is a power of 2.
+	 * 
+	 * @param in A Vector to be FFT'd
+	 * @return A transformed array of (real,img)-pairs
+	 */
+	private double[][][] FFT(double[][] x) {
+		return FFT.fftReal1Dor2D(x);
+	}
+
+	/**
+	 * Does Convolution for two FFT arrays, handles 
+	 * @param vx FFT'd x vector, of power-of-2 size
+	 * @param vy FFT'd y vector, of length smaller than equal to vx
+	 * @return A real array containing the result (non-zero-padded part of it)
+	 */
+	private double[][] ConvolveWithPreFFTandStrip(double[][][] fftx, double[][][] ffty) {
+		assert fftx.length == ffty.length: "Convolve: row count not equal";
+		assert fftx[0].length == ffty[0].length: "Convolve: col count not equal";
+		//System.out.println(Arrays.deepToString(fftx));
+		//System.out.println(Arrays.deepToString(ffty));
+		
+		double[][] convolved = FFT.convolveWithPreFFT(fftx,ffty);
+		//System.out.println(Arrays.deepToString(convolved));
+		int rows = convolved.length;
+		int cols = convolved[0].length;
+		double[][] stripped = new double[validRows][];
+		
+		for(int i = 0; i < validRows; ++i) {
+			stripped[i] = Arrays.copyOfRange(convolved[rows-validRows+i], cols-validCols, cols);
+		}
+		//System.out.println(Arrays.deepToString(stripped));
+		return stripped;
+	}
+	
+	/**
+	 * Converts from row-major vector to matrix (a11 a12 a13 a21 a22 a23..) => (a11 a12 a13; a21 a22 a23;...)
+	 * @param rows number of rows in the matrix
+	 * @param cols number of cols in the matrix
+	 * @param x the vector containing the values
+	 * @return a (rows,cols)-matrix containing the values
+	 */
+	private double[][] vectorToMatrix(int rows, int cols, double[] x) {
+		if(rows*cols != x.length) throw new RuntimeException("The wanted matrix size differs from the vector length");
+		
+		double[][] y = new double[rows][cols];
+		for(int j = 0; j < rows; ++j) {
+			for(int i = 0; i < cols; ++i) {
+				y[j][i] = x[i+j*cols];
+			}
+		}
+		return y;
+	}
+	
+	/**
+	 * Converts from matrix to row-major vector  (a11 a12 a13; a21 a22 a23;...) => (a11 a12 a13 a21 a22 a23..)
+	 * @param x the matrix containing the values
+	 * @param add value to be added to each cell
+	 * @return a row-major vector containing the values
+	 */
+	private double[] matrixToVector(double[][] x, double add) {
+		int rows = x.length;
+		int cols = x[0].length;
+		double[] y = new double[rows*cols];
+		for(int j = 0; j < rows; ++j) {
+			for(int i = 0; i < cols; ++i) {
+				y[i+j*cols] = x[j][i] + add;
+			}
+		}
+		return y;
+	}
+	
+	/**
+	 * Pads a matrix with zeros to right and below to match given size
+	 * 
+	 * @param rows
+	 * @param cols
+	 * @param x
+	 * @return
+	 */
+	private double[][] pad(int rows, int cols, double[][] x) {
+		int xrows = x.length;
+		
+		double[][] y = new double[rows][];
+		for(int j = 0; j < xrows; ++j) {
+			y[j] = Arrays.copyOf(x[j], cols); // the rest is filled with zeros 
+		}
+		for(int j = xrows; j < rows; ++j) {
+			y[j] = new double[cols]; // the rest is filled with zeros
+		}
+		return y;
+	}
+	
+	/**
+	 * Flips a matrix: (a11 a12; a21 a22) => (a22 a21; a12 a11)
+	 * @param x matrix to flip
+	 * @return flipped matrix
+	 */
+	private double[][] flip(double[][] x) {
+		int rows = x.length;
+		int cols = x[0].length;
+		double[][] y = new double[rows][cols];
+		for(int j = 0; j < rows; ++j) { // looping over X's rows
+			for(int i = 0; i < cols; ++i) { // looping over X's cols
+				y[j][i] = x[rows-j-1][cols-i-1];
+			}
+		}
+		return y;
+	}
+
+}

--- a/deeplearning/src/test/java/FFTConvolutionTest.java
+++ b/deeplearning/src/test/java/FFTConvolutionTest.java
@@ -1,0 +1,202 @@
+package test.java;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.Serializable;
+
+import main.java.FFT;
+import main.java.FFTConvolutionExtractor;
+import main.java.DeepModelSettings.ConfigBaseLayer;
+import main.java.DeepModelSettings.ConfigFeatureExtractor;
+import main.java.DeepModelSettings.ConfigPooler;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.mllib.linalg.DenseVector;
+import org.apache.spark.mllib.linalg.Vector;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FFTConvolutionTest implements Serializable {
+	
+	private static final long serialVersionUID = 2780960378816038954L;
+	private transient JavaSparkContext sc;
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+		sc = new JavaSparkContext("local", "MaxPoolerTest");
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+		sc.stop();
+		sc = null;
+	}
+
+	public boolean deepApproximateEquals(double[][][] x, double[][][] y, double epsilon) {
+		if(x.length != y.length) fail("1D lengths differ");
+		for(int i = 0; i < x.length; ++i) {
+			if(x[i].length != y[i].length) fail("2D lengths differ at " + i);
+			for(int j = 0; j < x[i].length; ++j) {
+				if(x[i][j].length != y[i][j].length) fail("3D lengths differ at " + i + " , " + j);
+				for(int k = 0; k < x[i][j].length; ++k) {
+					if(Math.abs(x[i][j][k] - y[i][j][k]) > epsilon ) {
+						fail("Values at " + i + "-" + j + "-" + k + " differ: " +  x[i][j][k] + " vs. " + y[i][j][k]);
+						return false;
+					}
+				}
+			}
+		}
+		return true;
+	}
+	
+	@Test
+	public void simpleTest1DFFT() {
+		double[][] input =   {{1,2,3,0}};
+		double[][][] output = FFT.fftReal1Dor2D(input);
+		double[][][] expected = {{{6,0},{-2,-2},{2,0},{-2,2}}};
+		//System.out.println(Arrays.deepToString(output));
+		assertTrue(deepApproximateEquals(output, expected, 1e-2));
+	}
+	
+	@Test
+	public void simpleTest2DFFT() {
+		double[][] input =   {{1,2,3,0}, {4,5,6,0}, {7,8,9,0},{0,0,0,0}};
+		double[][][] output = FFT.fftReal1Dor2D(input);
+		//System.out.println(Arrays.deepToString(output));
+		double[][][] expected = {{{ 45,  0}, { -6,-15}, { 15,  0}, { -6, 15}},
+				 {{-18,-15}, { -5,  8}, { -6, -5}, {  5, -4}},
+				 {{ 15,  0}, { -2, -5}, {  5,  0}, { -2,  5}},
+				 {{-18, 15}, {  5,  4}, { -6,  5}, { -5, -8}}};
+
+		assertTrue(deepApproximateEquals(output, expected, 1e-2));
+	}
+	
+	@Test
+	public void simpleTest1DConvolution() {
+		int inputRows = 1;
+		int inputCols = 4;
+		int featureRows = 1;
+		int featureCols = 2;
+		double[] input =   {1,2,3,0};
+	    
+		ConfigBaseLayer conf = ConfigBaseLayer.newBuilder().
+				setConfigFeatureExtractor(ConfigFeatureExtractor.newBuilder().
+						                  setFeatureDim1(featureCols).setFeatureDim2(featureRows).
+						                  setInputDim1(inputCols).setInputDim2(inputRows)).
+			    setConfigPooler(ConfigPooler.newBuilder().setPoolSize(1)).build();
+		FFTConvolutionExtractor extractor = new FFTConvolutionExtractor(conf, null); // no pre-processing yet
+
+		Vector data = new DenseVector(input);
+		
+		double[] A = {1,2};
+		
+		Vector[] features = {new DenseVector(A)};
+		extractor.setFeatures(features);
+		Vector output;
+		try {
+			output = extractor.call(data);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail("Call threw exception");
+			return;
+		}
+		//System.out.println(Arrays.toString(output.toArray()));
+		double[] expected_outputs = {5,8,3};
+		Assert.assertArrayEquals(expected_outputs, output.toArray(), 1e-6);
+	}
+	
+	@Test
+	public void simpleTest2DConvolution() {
+		int inputRows = 4;
+		int inputCols = 4;
+		int featureRows = 2;
+		int featureCols = 2;
+		double[] input =   {1,2,3,0,
+							4,5,6,0,
+							7,8,9,0,
+							0,0,0,0};
+	    
+		ConfigBaseLayer conf = ConfigBaseLayer.newBuilder().
+				setConfigFeatureExtractor(ConfigFeatureExtractor.newBuilder().
+						                  setFeatureDim1(featureCols).setFeatureDim2(featureRows).
+						                  setInputDim1(inputCols).setInputDim2(inputRows)).
+			    setConfigPooler(ConfigPooler.newBuilder().setPoolSize(1)).build();
+		FFTConvolutionExtractor extractor = new FFTConvolutionExtractor(conf, null); // no pre-processing yet
+
+		Vector data = new DenseVector(input);
+		
+		double[] A = {1,2,
+					  0,0};
+		
+		Vector[] features = {new DenseVector(A)};
+		extractor.setFeatures(features);
+		Vector output;
+		try {
+			output = extractor.call(data);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail("Call threw exception");
+			return;
+		}
+		//System.out.println(Arrays.toString(output.toArray()));
+		double[] expected_outputs = {5,8,3,
+									 14,17,6,
+									 23,26,9};
+		Assert.assertArrayEquals(expected_outputs, output.toArray(), 1e-6);
+	}
+	
+	// TODO Write test case that uses pre-processing
+	
+	/*// Meh boooring
+	@Test
+	public void test2DConvolution() {
+		int inputRows = 8;
+		int inputCols = 16;
+		int featureRows = 4;
+		int featureCols = 4;
+		double[] input =  {0.7803,   0.5752,   0.6491,   0.6868,   0.4868,   0.6443,   0.6225,   0.2259,   0.9049,   0.6028,   0.0855,   0.2373,   0.6791,   0.0987,   0.4942,   0.0305,
+	    					0.3897,   0.0598,   0.7317,   0.1835,   0.4359,   0.3786,   0.5870,   0.1707,   0.9797,   0.7112,   0.2625,   0.4588,   0.3955,   0.2619,   0.7791,   0.7441,
+	    					0.2417,   0.2348,   0.6477,   0.3685,   0.4468,   0.8116,   0.2077,   0.2277,   0.4389,   0.2217,   0.8010,   0.9631,   0.3674,   0.3354,   0.7150,   0.5000,
+	    					0.4039,   0.3532,   0.4509,   0.6256,   0.3063,   0.5328,   0.3012,   0.4357,   0.1111,   0.1174,   0.0292,   0.5468,   0.9880,   0.6797,   0.9037,   0.4799,
+	    					0.0965,   0.8212,   0.5470,   0.7802,   0.5085,   0.3507,   0.4709,   0.3111,   0.2581,   0.2967,   0.9289,   0.5211,   0.0377,   0.1366,   0.8909,   0.9047,
+	    					0.1320,   0.0154,   0.2963,   0.0811,   0.5108,   0.9390,   0.2305,   0.9234,   0.4087,   0.3188,   0.7303,   0.2316,   0.8852,   0.7212,   0.3342,   0.6099,
+	    					0.9421,   0.0430,   0.7447,   0.9294,   0.8176,   0.8759,   0.8443,   0.4302,   0.5949,   0.4242,   0.4886,   0.4889,   0.9133,   0.1068,   0.6987,   0.6177,
+	    					0.9561,   0.1690,   0.1890,   0.7757,   0.7948,   0.5502,   0.1948,   0.1848,   0.2622,   0.5079,   0.5785,   0.6241,   0.7962,   0.6538,   0.1978,   0.8594};
+	    
+		ConfigBaseLayer conf = ConfigBaseLayer.newBuilder().
+				setConfigFeatureExtractor(ConfigFeatureExtractor.newBuilder().
+						                  setFeatureDim1(featureCols).setFeatureDim2(featureRows).
+						                  setInputDim1(inputCols).setInputDim2(inputRows)).build();
+		FFTConvolutionExtractor extractor = new FFTConvolutionExtractor(conf, null); // no pre-processing yet
+
+		Vector data = new DenseVector(input);
+		
+		double[] A = {	0.8055,    0.8865,    0.9787,    0.0596,
+			    		0.5767,    0.0287,    0.7127,    0.6820,
+			    		0.1829,    0.4899,    0.5005,    0.0424,
+			    		0.2399,    0.1679,    0.4711,    0.0714};
+		
+		Vector[] features = {new DenseVector(A)};
+		
+		Vector output;
+		try {
+			output = extractor.call(data);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail("Call threw exception");
+		}
+		double[] expected_outputs = {8,10,12,20,22,24};
+		Assert.assertArrayEquals(expected_outputs, output.toArray(), 1e-6);
+	}
+*/
+
+}


### PR DESCRIPTION
The file FFT.java contains and implementation of FFT for power-of-two
vectors and, using that, inverse-FFT and generalizations to 2D.
Everything is based on fft1D(), so changing that to use something else
than the naive FFT implementation that is included would a) make things
faster and b) allow non-power-of-2 lengths.

FFT.java contains also convolution, that can be used with pre-calculated
FFTs. Does not strip the results, as it has no information about
padding, so the whole 0-padded circular convolution is returned.

FFTConvolutionExtractor implementes Extractor using the FFT class.
When setFeatures() is called, the FFT's of the features are calculated
and stored. When call() is called, the FFT for that data vector is
calculated, and then it is convolved with each pre-calculated feature
FFT, and the result is stripped to contain only valid cells. The results
are stored in a single vector, with each feature being row-major and
featues are one after another, in the same order as they were given to
setFeatures(). Preprocessing, if PreProcessZCA is used, is taken care
of.

FFTConvolutionTest.java test the FFT operations and the
FFTConvolutionExtractor with both vector and matrix data/features.
Preprocessing is not tested yet.
